### PR TITLE
Type aliases

### DIFF
--- a/example/index.sirius
+++ b/example/index.sirius
@@ -7,6 +7,8 @@ enum LinkedList[a] {
   Cons(a, ref LinkedList[a])
 }
 
+type Test[a] = ref LinkedList[a];
+
 fn (c: String) ==(other: String): Bool = strcmp(c, other) == 0;
 
 fn (c: a) typeOf[a](): String = asm "extractvalue" (asm "extractvalue" c 0) 0;
@@ -44,7 +46,10 @@ fn (c: Unit) show(): String = "Unit";
 fn main(): Int = {
   // print(Cons(5, ref Nil));
   print(test("bruh")());
-  print(Cons(5, ref Cons(4, ref Cons(3, ref Nil))).len());
+  
+  let x: Test[Int] = ref Nil;
+
+  print(Cons(5, ref Cons(4, ref Cons(3, x))).len());
   print(Unit);
   0
 }

--- a/src/Language/Sirius/CST/Expression.hs
+++ b/src/Language/Sirius/CST/Expression.hs
@@ -72,6 +72,7 @@ data Toplevel
   --   The second argument is a list of toplevel declarations
   | TAnnotation Text (Located Toplevel)
   | TEnumeration (Annoted [Generic]) [Annoted [Type]]
+  | TTypeAlias (Annoted [Generic]) Type
   deriving (Eq, Show)
 
 data Expression

--- a/src/Language/Sirius/LLVM/Codegen.hs
+++ b/src/Language/Sirius/LLVM/Codegen.hs
@@ -407,6 +407,13 @@ genUpdate (T.UInternalField expr _) = do
   Just <$> IRB.gep expr' [AST.int32 0, AST.int32 0]
 
 parseAssembly :: LLVM m => T.Expression -> m (Maybe AST.Operand)
+parseAssembly (T.EAssembly "alloca" ((T.ESizeOf t):i:_)) = do
+  t' <- fromType t
+  i' <- genExpression i
+  Just <$> IRB.alloca t' i' 0
+parseAssembly (T.EAssembly "alloca" ((T.ESizeOf t):_)) = do
+  t' <- fromType t
+  Just <$> IRB.alloca t' Nothing 0
 parseAssembly (T.EAssembly "extractvalue" (x:(T.ELiteral (L.Int i)):_)) = do
   x' <- fromJust <$> genExpression x
   Just <$> IRB.extractValue x' [fromIntegral i]

--- a/src/Language/Sirius/Parser/Toplevel.hs
+++ b/src/Language/Sirius/Parser/Toplevel.hs
@@ -15,6 +15,15 @@ parseImport =
     name <- (:) <$> L.identifier <*> P.many (P.string "." *> L.identifier)
     return $ C.TUse name
 
+parseTypeAlias :: Monad m => L.Sirius m C.Toplevel
+parseTypeAlias =
+  L.lexeme $ do
+    L.reserved "type"
+    name <- L.identifier
+    gens <- P.option [] $ L.brackets $ L.commaSep L.identifier
+    L.reservedOp "="
+    C.TTypeAlias (C.Annoted name gens) <$> T.parseType
+
 parseEnumeration :: Monad m => L.Sirius m C.Toplevel
 parseEnumeration =
   L.lexeme $ do
@@ -137,6 +146,7 @@ parseToplevel p =
   P.choice
     [ parseImport
     , parseAnnotation p
+    , parseTypeAlias
     , parseEnumeration
     , P.try $ parsePropFunction p
     , parseFunction p

--- a/src/Language/Sirius/Typecheck/Definition/Monad.hs
+++ b/src/Language/Sirius/Typecheck/Definition/Monad.hs
@@ -33,6 +33,7 @@ data CheckerState =
     , returnType  :: T.Type
     , classes     :: M.Map (T.Type, Text) T.Scheme
     , staticFns   :: M.Map (T.Type, Text) T.Scheme
+    , aliases     :: M.Map Text T.Scheme
     }
   
 instance Semigroup CheckerState where
@@ -46,6 +47,7 @@ instance Semigroup CheckerState where
       , returnType = if returnType s1 == T.Void then returnType s2 else returnType s1
       , classes = classes s1 `M.union` classes s2
       , staticFns = staticFns s1 `M.union` staticFns s2
+      , aliases = aliases s1 `M.union` aliases s2
       }
 
 instance Monoid CheckerState where
@@ -59,6 +61,7 @@ instance Monoid CheckerState where
       , returnType = T.Void
       , classes = mempty
       , staticFns = mempty
+      , aliases = mempty
       }
 
 union' :: Envs -> Envs -> Envs

--- a/src/Language/Sirius/Typecheck/Modules/Parser.hs
+++ b/src/Language/Sirius/Typecheck/Modules/Parser.hs
@@ -7,11 +7,11 @@ module Language.Sirius.Typecheck.Modules.Parser where
 import qualified Control.Monad.State                        as ST
 import qualified Data.Map                                   as M
 import qualified Language.Sirius.CST.Modules.Type           as D
-import           Language.Sirius.Typecheck.Definition.Monad (MonadChecker)
 import qualified Language.Sirius.Typecheck.Definition.Monad as M
 import qualified Language.Sirius.Typecheck.Definition.Monad as T
 import qualified Language.Sirius.Typecheck.Definition.Type  as T
 import qualified Language.Sirius.CST.Modules.Namespaced as D
+import qualified Language.Sirius.Typecheck.Modules.Substitution as U
 
 class Parser a where
   to :: T.MonadChecker m => a -> m T.Type
@@ -19,7 +19,7 @@ class Parser a where
   toWithEnv :: T.MonadChecker m => a -> M.Map Text T.Type -> m T.Type
   from :: T.Type -> a
 
-withGenerics :: MonadChecker m => M.Map Text T.Type -> m a -> m a
+withGenerics :: T.MonadChecker m => M.Map Text T.Type -> m a -> m a
 withGenerics xs m = do
   ST.modify (\s -> s {M.generics = xs `M.union` M.generics s})
   a <- m
@@ -38,11 +38,16 @@ instance Parser D.Type where
     where
       go :: T.MonadChecker m => D.Type -> M.Map Text T.Type -> m T.Type
       go (D.TypeApp (D.Simple v) xs) env = do
-        if null xs
-          then return $ T.TId v
-          else do
-            ts <- mapM (`go` env) xs
-            return (T.TApp (T.TId v) ts)
+        ts <- mapM (`go` env) xs
+        aliases <- ST.gets T.aliases
+        case M.lookup v aliases of
+          Just (T.Forall gens t) -> do
+            let env' = M.fromList (zip gens ts)
+            return (U.apply env' t)
+          _ -> if null xs
+            then return $ T.TId v
+            else do
+              return (T.TApp (T.TId v) ts)
       go (D.TypeVar (D.Simple v)) env = do
         case M.lookup v env of
           Just t -> return t
@@ -50,8 +55,14 @@ instance Parser D.Type where
             env' <- ST.gets T.types
             case M.lookup v env' of
               Just _ -> return $ T.TId v
-              Nothing -> T.fresh
-            -- maybe T.fresh T.instantiate (M.lookup v env')
+              Nothing -> do
+                aliases <- ST.gets T.aliases
+                case M.lookup v aliases of
+                  Just (T.Forall gens t) -> do
+                    if null gens then
+                      return t
+                    else error "go: TypeVar"
+                  Nothing -> T.fresh
       go D.TypeInt _ = return T.Int
       go D.TypeBool _ = return T.Bool
       go D.TypeFloat _ = return T.Float


### PR DESCRIPTION
Adding type aliases support to Sirius via the following syntax:

```rs
type Parser[a] = fun(String): a;
type String = [Char]
```

It supports type aliasing with generics support, and should be eliminated through the typechecking process.